### PR TITLE
Make icons size consistent with other panel items

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -7,7 +7,7 @@ const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 const System = imports.system;
 
-const TRAY_ICON_SIZE = 14;
+const TRAY_ICON_SIZE = 18;
 
 let tray = null;
 let icons = [];

--- a/extension.js
+++ b/extension.js
@@ -7,7 +7,7 @@ const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 const System = imports.system;
 
-const TRAY_ICON_SIZE = 18;
+const TRAY_ICON_SIZE = 14;
 
 let tray = null;
 let icons = [];

--- a/extension.js
+++ b/extension.js
@@ -7,7 +7,7 @@ const Shell = imports.gi.Shell;
 const St = imports.gi.St;
 const System = imports.system;
 
-const TRAY_ICON_SIZE = 22;
+const TRAY_ICON_SIZE = 18;
 
 let tray = null;
 let icons = [];


### PR DESCRIPTION
The icons are too large to look consistent with other panel items:
![image](https://user-images.githubusercontent.com/7802808/127783471-0ca56281-5da5-432f-899c-c20cdda97187.png)

I propose to decrease the size so that it's in sync with the network, audio and battery icons. 

The 18 number is not accurate, because I still found no time to research extension development.
It would be great if someone can post screenshot of this version